### PR TITLE
Remove null byte from proctitle

### DIFF
--- a/lib/loops/commands/monitor_command.rb
+++ b/lib/loops/commands/monitor_command.rb
@@ -4,7 +4,7 @@ class Loops::Commands::MonitorCommand < Loops::Command
     Loops.logger.write_to_console = true
 
     # Set process name
-    $0 = "loops monitor: #{options[:args].join(' ') rescue 'all'}\0"
+    $0 = "loops monitor: #{options[:args].join(' ') rescue 'all'}"
 
     # Start loops and let the monitor process take over
     puts "Starting loops in monitor mode..."

--- a/lib/loops/commands/start_command.rb
+++ b/lib/loops/commands/start_command.rb
@@ -8,7 +8,7 @@ class Loops::Commands::StartCommand < Loops::Command
 
     # Daemonization
     if options[:daemonize]
-      app_name = "loops monitor: #{options[:args].join(' ') rescue 'all'}\0"
+      app_name = "loops monitor: #{options[:args].join(' ') rescue 'all'}"
       Loops::Daemonize.daemonize(app_name)
     end
 


### PR DESCRIPTION
This has been running in production for a while. I think it's ready to merge into master of our fork.

From @look's commit:
> Null bytes cause problems with NewRelic RPM:
> 
> ERROR : Failed to harvest profile_data data, resetting. Error:
> ERROR : ArgumentError: string contains null byte
> 
> This happens because File.basename raises an exception when the string
> contains a null byte.
> 
> According to @ageweke in 32791ce1531a8cf9f533254204694915394fecba using
> a null byte is no longer necessary. I have not found any examples online
> that use the null byte.
