### PR TITLE
Stop inheriting write_to_console after forking

### DIFF
--- a/lib/loops/engine.rb
+++ b/lib/loops/engine.rb
@@ -154,6 +154,7 @@ class Loops::Engine
             if Loops.logger.is_a?(Loops::Logger) && @global_config['workers_engine'] == 'fork'
               # this is happening right after the fork, therefore no need for teardown at the end of the proc
               Loops.logger.logfile = config['logger'] if config['logger']
+              Loops.logger.write_to_console = false
               Loops.logger
             else
               # for backwards compatibility and handling threading engine


### PR DESCRIPTION
Without this change, the monitoring/parent process sets
`write_to_console = true` and then when the child workers fork
that setting is still true on Loops.logger. Even though we basically
never want that and it’s inconsistent with the threading engine which
creates a brand new logger.