### PR TITLE
Close and reconnect each mongo client after fork

### DIFF
--- a/lib/loops/engine.rb
+++ b/lib/loops/engine.rb
@@ -251,7 +251,13 @@ class Loops::Engine
       end
     end
 
+    # https://docs.mongodb.com/mongoid/7.0/tutorials/mongoid-configuration/#usage-with-forking-servers
     def disconnect_mongoid
-      ::Mongoid::Clients.disconnect if defined?(::Mongoid::Clients)
+      if defined?(::Mongoid::Clients)
+        ::Mongoid::Clients.clients.each do |_name, client|
+          client.close
+          client.reconnect
+        end
+      end
     end
 end


### PR DESCRIPTION
This change is an addendum to https://github.com/swiftype/loops/pull/4

Simply closing the mongo connections didn't suffice, as the monitoring thread didn't start up again for each worker, resulting in them not seeing mongo topologoy changes.

Following Mongoid's documentation and using close+reconnect achieves the desired behaviour where each worker has an active monitoring thread and responds correctly to topology changes.

See https://docs.mongodb.com/mongoid/7.0/tutorials/mongoid-configuration/#usage-with-forking-servers